### PR TITLE
[#7] feat: 카테고리 상세 보기 API + 카테고리 DB 설정 migrate 파일

### DIFF
--- a/categories/migrations/0002_auto_add_initial_data.py
+++ b/categories/migrations/0002_auto_add_initial_data.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+def create_categories(apps, schema_editor):
+    Category = apps.get_model('categories', 'Category')
+    Category.objects.bulk_create([
+        Category(name='식자재'),
+        Category(name='한식'),
+        Category(name='중식'),
+        Category(name='일식'),
+        Category(name='양식'),
+        Category(name='분식'),
+        Category(name='카페/음료'),
+        Category(name='패스트푸드'),
+        Category(name='치킨'),
+        Category(name='피자'),
+        Category(name='베이커리'),
+        Category(name='기타')
+    ])
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('categories', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_categories),
+    ]

--- a/categories/serializers.py
+++ b/categories/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import *
+
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = ['id', 'name']

--- a/categories/urls.py
+++ b/categories/urls.py
@@ -3,6 +3,8 @@ from django.urls import path, include
 from .views import *
 
 router = DefaultRouter()
+router.register(r'', CategoryViewset, basename = 'category')
+
 urlpatterns = [
-    path('categories/', include(router.urls)),
+    path('', include(router.urls)),
 ]

--- a/categories/views.py
+++ b/categories/views.py
@@ -1,3 +1,12 @@
 from django.shortcuts import render
 
-# Create your views here.
+from rest_framework import viewsets
+from .models import Category
+from .serializers import CategorySerializer
+
+from rest_framework.permissions import AllowAny
+
+class CategoryViewset(viewsets.ReadOnlyModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = [AllowAny] #권한 없음


### PR DESCRIPTION
## ✨ 작업 개요
- 카테고리 목록 보기 + 카테고리 DB 파일 migration 할 때 생성되도록 migrations 파일 업로드

## ✅ 주요 작업 내용
- ~ API 구현 및 url 라우팅
- ~ Category 모델 기초 정보 자동 마이그레이션 설정

## 🔄 관련 이슈
Closes #7 

## 📎 참고 자료 (선택)
- API 명세서: https://www.notion.so/243d525961ec80269468c2737fbbc7d7?v=243d525961ec8166b3ec000c7cd08389

## 📝 비고
