### PR TITLE
[#77] Fix: 비활성화된 상품 찜 목록에서 제거

### DIFF
--- a/products/apps.py
+++ b/products/apps.py
@@ -1,6 +1,9 @@
 from django.apps import AppConfig
 
 
-class ProductConfig(AppConfig):
+class ProductsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'products'
+
+    def ready(self):
+        import products.signals

--- a/products/signals.py
+++ b/products/signals.py
@@ -1,0 +1,8 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Product, Wishlist
+
+@receiver(post_save, sender=Product) # 물건 비활성화 될 시 연결된 찜 삭제
+def remove_wishlist_if_inactive(sender, instance, **kwargs):
+    if not instance.is_active:
+        Wishlist.objects.filter(product=instance).delete()

--- a/project/settings.py
+++ b/project/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'drf_yasg',
     
+    'products.apps.ProductsConfig',
 
     'accounts',
     'categories',


### PR DESCRIPTION
## ✨ 작업 개요
- 유통기한 만료로 비활성화된 상품 소비자 찜 목록에서 제거

## ✅ 주요 작업 내용
- ~ signals.py, apps.py 생성 및 수정 

## 🔄 관련 이슈
Closes #77 

## 📎 참고 자료

## 📝 비고